### PR TITLE
RMET-306 - Crash on deleting contact

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-contacts",
-  "version": "3.0.1-OS2",
+  "version": "3.0.1-OS3",
   "description": "Cordova Contacts Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,7 @@
     xmlns:m3="http://schemas.microsoft.com/appx/2014/manifest"
     xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
     id="cordova-plugin-contacts"
-    version="3.0.1-OS2">
+    version="3.0.1-OS3">
 
     <name>Contacts</name>
     <description>Cordova Contacts Plugin</description>

--- a/src/ios/CDVContacts.m
+++ b/src/ios/CDVContacts.m
@@ -597,7 +597,7 @@
     // NSLog(@"addressBook access: %lu", status);
     ABAddressBookRequestAccessWithCompletion(addressBook, ^(bool granted, CFErrorRef error) {
             // callback can occur in background, address book must be accessed on thread it was created on
-            dispatch_sync(dispatch_get_main_queue(), ^{
+            dispatch_async(dispatch_get_main_queue(), ^{
                 if (error) {
                     workerBlock(NULL, [[CDVAddressBookAccessError alloc] initWithCode:UNKNOWN_ERROR]);
                 } else if (!granted) {

--- a/src/ios/CDVContacts.m
+++ b/src/ios/CDVContacts.m
@@ -589,13 +589,13 @@
     // TODO: this probably should be reworked - seems like the workerBlock can just create and release its own AddressBook,
     // and also this important warning from (http://developer.apple.com/library/ios/#documentation/ContactData/Conceptual/AddressBookProgrammingGuideforiPhone/Chapters/BasicObjects.html):
     // "Important: Instances of ABAddressBookRef cannot be used by multiple threads. Each thread must make its own instance."
-    ABAddressBookRef addressBook;
-
-    CFErrorRef error = nil;
-    // CFIndex status = ABAddressBookGetAuthorizationStatus();
-    addressBook = ABAddressBookCreateWithOptions(NULL, &error);
-    // NSLog(@"addressBook access: %lu", status);
-    ABAddressBookRequestAccessWithCompletion(addressBook, ^(bool granted, CFErrorRef error) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        ABAddressBookRef addressBook;
+        CFErrorRef error = nil;
+        // CFIndex status = ABAddressBookGetAuthorizationStatus();
+        addressBook = ABAddressBookCreateWithOptions(NULL, &error);
+        // NSLog(@"addressBook access: %lu", status);
+        ABAddressBookRequestAccessWithCompletion(addressBook, ^(bool granted, CFErrorRef error) {
             // callback can occur in background, address book must be accessed on thread it was created on
             dispatch_async(dispatch_get_main_queue(), ^{
                 if (error) {
@@ -608,6 +608,8 @@
                 }
             });
         });
+    });
+
 }
 
 @end


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail --> 
The createAddressBook function was called on the main thread(which is serial) and on the callback had a dispatch_sync for  the main thread, this caused an EXC_BAD_ACCESS and crash

Changed the dispatch_sync to dispatch_async.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Closes the issue: https://outsystemsrd.atlassian.net/browse/RMET-306

<!--- Why is this change required? What problem does it solve? -->
Solves a crash.
 
## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [x] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
Executed the P0s tests of the test plan
<!--- Include details of your test environment if relevant -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly