### PR TITLE
RMET-562 - Contacts Plugin: Application crashes when trying to pick contact

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-contacts",
-  "version": "3.0.1-OS3",
+  "version": "3.0.1-OS4",
   "description": "Cordova Contacts Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,7 @@
     xmlns:m3="http://schemas.microsoft.com/appx/2014/manifest"
     xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
     id="cordova-plugin-contacts"
-    version="3.0.1-OS3">
+    version="3.0.1-OS4">
 
     <name>Contacts</name>
     <description>Cordova Contacts Plugin</description>

--- a/src/ios/CDVContacts.m
+++ b/src/ios/CDVContacts.m
@@ -211,12 +211,14 @@
     // if no permissions granted try to request them first
     if (status == kABAuthorizationStatusNotDetermined) {
         ABAddressBookRequestAccessWithCompletion(addressBook, ^(bool granted, CFErrorRef error) {
-            if (granted) {
-                [self chooseContact:newCommand];
-                return;
-            }
-
-            [self.commandDelegate sendPluginResult: errorResult callbackId:command.callbackId];
+            dispatch_sync(dispatch_get_main_queue(), ^{
+                if (granted) {
+                    [self chooseContact:newCommand];
+                    return;
+                }
+            
+                [self.commandDelegate sendPluginResult: errorResult callbackId:command.callbackId];
+            });
         });
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail --> 
The app crashes after the permissions window appears and you click "allow." If you re-open the app, the permission is granted and you can access the contacts correctly.

Its necessary to add this fix to outsystems branch https://github.com/apache/cordova-plugin-contacts/pull/229/files

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Closes the issue: https://outsystemsrd.atlassian.net/browse/RMET-562

<!--- Why is this change required? What problem does it solve? -->
Address book must be accessed on thread it was created on. In this case main thread.
 
## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [x] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
Executed the P0s tests of the test plan
<!--- Include details of your test environment if relevant -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly