### PR TITLE
RMET-1301 Contacts Plugin - Show no permissions dialog when permissions are denied

### DIFF
--- a/src/ios/CDVContacts.m
+++ b/src/ios/CDVContacts.m
@@ -210,28 +210,10 @@
     
     //if status is denied, we want to show the dialog allowing the user to go to the settings
     if (status == kABAuthorizationStatusDenied) {
-        //[self.commandDelegate sendPluginResult: errorResult callbackId:command.callbackId];
-        //return;
-        
         dispatch_async(dispatch_get_main_queue(), ^{
-            /*
-            UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] message:NSLocalizedString(@"Access to the contacts has been prohibited. Please enable it in the Settings app to continue.", nil) preferredStyle:UIAlertControllerStyleAlert];
-            [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                [self.commandDelegate sendPluginResult: errorResult callbackId:command.callbackId];
-            }]];
-            [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Settings", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
-                [self.commandDelegate sendPluginResult: errorResult callbackId:command.callbackId];
-            }]];
-            [self.viewController presentViewController:alertController animated:YES completion:nil];
-            return;
-            */
-            
             [self showNoPermissionDialog:command.callbackId andResult:errorResult];
             return;
-            
         });
-        
     }
 
     // if no permissions granted try to request them first
@@ -242,24 +224,9 @@
                     [self chooseContact:newCommand];
                     return;
                 }
-            
-                //[self.commandDelegate sendPluginResult: errorResult callbackId:command.callbackId];
-                /*
-                UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] message:NSLocalizedString(@"Access to the contacts has been prohibited. Please enable it in the Settings app to continue.", nil) preferredStyle:UIAlertControllerStyleAlert];
-                [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                    [self.commandDelegate sendPluginResult: errorResult callbackId:command.callbackId];
-                }]];
-                [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Settings", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
-                    [self.commandDelegate sendPluginResult: errorResult callbackId:command.callbackId];
-                }]];
-                [self.viewController presentViewController:alertController animated:YES completion:nil];
-                return;
-                 */
-                
+                //if permissions are denied, show dialog and send error
                 [self showNoPermissionDialog:command.callbackId andResult:errorResult];
                 return;
-                
             });
         });
     }
@@ -361,31 +328,11 @@
         [abHelper createAddressBook: ^(ABAddressBookRef addrBook, CDVAddressBookAccessError* errCode) {
             if (addrBook == NULL) {
                 
-                /*
-                // permission was denied or other error - return error
                 CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageToErrorObject:errCode ? (int)errCode.errorCode:UNKNOWN_ERROR];
-                [weakSelf.commandDelegate sendPluginResult:result callbackId:callbackId];
-                return;
-                 */
                 
                 ABAuthorizationStatus status = ABAddressBookGetAuthorizationStatus();
                 if (status == kABAuthorizationStatusDenied) {
                     dispatch_async(dispatch_get_main_queue(), ^{
-                        /*
-                        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] message:NSLocalizedString(@"Access to the contacts has been prohibited. Please enable it in the Settings app to continue.", nil) preferredStyle:UIAlertControllerStyleAlert];
-                        [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageToErrorObject:errCode ? (int)errCode.errorCode:UNKNOWN_ERROR];
-                            [weakSelf.commandDelegate sendPluginResult:result callbackId:callbackId];
-                        }]];
-                        [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Settings", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                            [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
-                            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageToErrorObject:errCode ? (int)errCode.errorCode:UNKNOWN_ERROR];
-                            [weakSelf.commandDelegate sendPluginResult:result callbackId:callbackId];
-                        }]];
-                        [weakSelf.viewController presentViewController:alertController animated:YES completion:nil];
-                        */
-                        
-                        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageToErrorObject:errCode ? (int)errCode.errorCode:UNKNOWN_ERROR];
                         
                         [weakSelf showNoPermissionDialog:callbackId andResult:result];
                         
@@ -394,7 +341,6 @@
                 }
                 
                 // some other error - return error
-                CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageToErrorObject:errCode ? (int)errCode.errorCode:UNKNOWN_ERROR];
                 [weakSelf.commandDelegate sendPluginResult:result callbackId:callbackId];
                 return;
             }
@@ -499,40 +445,18 @@
         [abHelper createAddressBook: ^(ABAddressBookRef addrBook, CDVAddressBookAccessError* errorCode) {
             CDVPluginResult* result = nil;
             if (addrBook == NULL) {
-                /*
-                // permission was denied or other error - return error
+
                 result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsInt:errorCode ? (int)errorCode.errorCode:UNKNOWN_ERROR];
-                [weakSelf.commandDelegate sendPluginResult:result callbackId:callbackId];
-                return;
-                 */
                 
                 ABAuthorizationStatus status = ABAddressBookGetAuthorizationStatus();
                 if (status == kABAuthorizationStatusDenied) {
                     dispatch_async(dispatch_get_main_queue(), ^{
-                        /*
-                        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] message:NSLocalizedString(@"Access to the contacts has been prohibited. Please enable it in the Settings app to continue.", nil) preferredStyle:UIAlertControllerStyleAlert];
-                        [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageToErrorObject:errorCode ? (int)errorCode.errorCode:UNKNOWN_ERROR];
-                            [weakSelf.commandDelegate sendPluginResult:result callbackId:callbackId];
-                        }]];
-                        [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Settings", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                            [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
-                            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageToErrorObject:errorCode ? (int)errorCode.errorCode:UNKNOWN_ERROR];
-                            [weakSelf.commandDelegate sendPluginResult:result callbackId:callbackId];
-                        }]];
-                        [weakSelf.viewController presentViewController:alertController animated:YES completion:nil];
-                        */
-                        
-                        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageToErrorObject:errorCode ? (int)errorCode.errorCode:UNKNOWN_ERROR];
-                        
                         [weakSelf showNoPermissionDialog:callbackId andResult:result];
-                        
                     });
                     return;
                 }
                 
                 // some other error - return error
-                CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageToErrorObject:errorCode ? (int)errorCode.errorCode:UNKNOWN_ERROR];
                 [weakSelf.commandDelegate sendPluginResult:result callbackId:callbackId];
                 return;
                 
@@ -604,45 +528,21 @@
         CDVPluginResult* result = nil;
         if (addrBook == NULL) {
             
-            /*
-            // permission was denied or other error - return error
             result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsInt:errorCode ? (int)errorCode.errorCode:UNKNOWN_ERROR];
-            [weakSelf.commandDelegate sendPluginResult:result callbackId:callbackId];
-            return;
-            */
             
         
             ABAuthorizationStatus status = ABAddressBookGetAuthorizationStatus();
             if (status == kABAuthorizationStatusDenied) {
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    /*
-                    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] message:NSLocalizedString(@"Access to the contacts has been prohibited. Please enable it in the Settings app to continue.", nil) preferredStyle:UIAlertControllerStyleAlert];
-                    [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageToErrorObject:errorCode ? (int)errorCode.errorCode:UNKNOWN_ERROR];
-                        [weakSelf.commandDelegate sendPluginResult:result callbackId:callbackId];
-                    }]];
-                    [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Settings", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
-                        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageToErrorObject:errorCode ? (int)errorCode.errorCode:UNKNOWN_ERROR];
-                        [weakSelf.commandDelegate sendPluginResult:result callbackId:callbackId];
-                    }]];
-                    [weakSelf.viewController presentViewController:alertController animated:YES completion:nil];
-                     */
-                    
-                    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageToErrorObject:errorCode ? (int)errorCode.errorCode:UNKNOWN_ERROR];
-                    
                     [weakSelf showNoPermissionDialog:callbackId andResult:result];
-                    
                 });
                 return;
             }
             
             // some other error - return error
-            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageToErrorObject:errorCode ? (int)errorCode.errorCode:UNKNOWN_ERROR];
             [weakSelf.commandDelegate sendPluginResult:result callbackId:callbackId];
             return;
              
-            
         }
 
         bool bIsError = FALSE, bSuccess = FALSE;

--- a/src/ios/CDVContacts.m
+++ b/src/ios/CDVContacts.m
@@ -214,6 +214,7 @@
         //return;
         
         dispatch_async(dispatch_get_main_queue(), ^{
+            /*
             UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] message:NSLocalizedString(@"Access to the contacts has been prohibited. Please enable it in the Settings app to continue.", nil) preferredStyle:UIAlertControllerStyleAlert];
             [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
                 [self.commandDelegate sendPluginResult: errorResult callbackId:command.callbackId];
@@ -224,6 +225,11 @@
             }]];
             [self.viewController presentViewController:alertController animated:YES completion:nil];
             return;
+            */
+            
+            [self showNoPermissionDialog:command.callbackId andResult:errorResult];
+            return;
+            
         });
         
     }
@@ -238,7 +244,7 @@
                 }
             
                 //[self.commandDelegate sendPluginResult: errorResult callbackId:command.callbackId];
-                
+                /*
                 UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] message:NSLocalizedString(@"Access to the contacts has been prohibited. Please enable it in the Settings app to continue.", nil) preferredStyle:UIAlertControllerStyleAlert];
                 [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
                     [self.commandDelegate sendPluginResult: errorResult callbackId:command.callbackId];
@@ -249,6 +255,11 @@
                 }]];
                 [self.viewController presentViewController:alertController animated:YES completion:nil];
                 return;
+                 */
+                
+                [self showNoPermissionDialog:command.callbackId andResult:errorResult];
+                return;
+                
             });
         });
     }
@@ -374,7 +385,9 @@
                         [weakSelf.viewController presentViewController:alertController animated:YES completion:nil];
                         */
                         
-                        [weakSelf showNoPermissionDialog:callbackId andErroDialog:errCode];
+                        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageToErrorObject:errCode ? (int)errCode.errorCode:UNKNOWN_ERROR];
+                        
+                        [weakSelf showNoPermissionDialog:callbackId andResult:result];
                         
                     });
                     return;
@@ -510,7 +523,9 @@
                         [weakSelf.viewController presentViewController:alertController animated:YES completion:nil];
                         */
                         
-                        [weakSelf showNoPermissionDialog:callbackId andErroDialog:errorCode];
+                        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageToErrorObject:errorCode ? (int)errorCode.errorCode:UNKNOWN_ERROR];
+                        
+                        [weakSelf showNoPermissionDialog:callbackId andResult:result];
                         
                     });
                     return;
@@ -614,7 +629,9 @@
                     [weakSelf.viewController presentViewController:alertController animated:YES completion:nil];
                      */
                     
-                    [weakSelf showNoPermissionDialog:callbackId andErroDialog:errorCode];
+                    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageToErrorObject:errorCode ? (int)errorCode.errorCode:UNKNOWN_ERROR];
+                    
+                    [weakSelf showNoPermissionDialog:callbackId andResult:result];
                     
                 });
                 return;
@@ -676,18 +693,16 @@
     return;
 }
 
-- (void)showNoPermissionDialog:(NSString*) callbackId andErroDialog:(CDVAddressBookAccessError*) errorCode {
+- (void)showNoPermissionDialog:(NSString*) callbackId andResult:(CDVPluginResult*) result {
     
     CDVContacts* __weak weakSelf = self;
     
     UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] message:NSLocalizedString(@"Access to the contacts has been prohibited. Please enable it in the Settings app to continue.", nil) preferredStyle:UIAlertControllerStyleAlert];
     [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageToErrorObject:errorCode ? (int)errorCode.errorCode:UNKNOWN_ERROR];
         [weakSelf.commandDelegate sendPluginResult:result callbackId:callbackId];
     }]];
     [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Settings", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
         [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
-        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageToErrorObject:errorCode ? (int)errorCode.errorCode:UNKNOWN_ERROR];
         [weakSelf.commandDelegate sendPluginResult:result callbackId:callbackId];
     }]];
     [weakSelf.viewController presentViewController:alertController animated:YES completion:nil];

--- a/src/ios/CDVContacts.m
+++ b/src/ios/CDVContacts.m
@@ -333,9 +333,7 @@
                 ABAuthorizationStatus status = ABAddressBookGetAuthorizationStatus();
                 if (status == kABAuthorizationStatusDenied) {
                     dispatch_async(dispatch_get_main_queue(), ^{
-                        
                         [weakSelf showNoPermissionDialog:callbackId andResult:result];
-                        
                     });
                     return;
                 }

--- a/src/ios/CDVContacts.m
+++ b/src/ios/CDVContacts.m
@@ -528,7 +528,6 @@
             
             result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsInt:errorCode ? (int)errorCode.errorCode:UNKNOWN_ERROR];
             
-        
             ABAuthorizationStatus status = ABAddressBookGetAuthorizationStatus();
             if (status == kABAuthorizationStatusDenied) {
                 dispatch_async(dispatch_get_main_queue(), ^{
@@ -591,8 +590,8 @@
     return;
 }
 
-- (void)showNoPermissionDialog:(NSString*) callbackId andResult:(CDVPluginResult*) result {
-    
+- (void)showNoPermissionDialog:(NSString*) callbackId andResult:(CDVPluginResult*) result
+{
     CDVContacts* __weak weakSelf = self;
     
     UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] message:NSLocalizedString(@"Access to the contacts has been prohibited. Please enable it in the Settings app to continue.", nil) preferredStyle:UIAlertControllerStyleAlert];
@@ -604,7 +603,6 @@
         [weakSelf.commandDelegate sendPluginResult:result callbackId:callbackId];
     }]];
     [weakSelf.viewController presentViewController:alertController animated:YES completion:nil];
-    
 }
 
 @end


### PR DESCRIPTION
## Description

- This PR is more of an improvement than a fix. When permissions to the contacts are denied, we will now show a dialog similar to the one in the Screenshot section.
- As such, this PR only adds code to show this new dialog. Method `showNoPermissionDialog` is used every time we detect that the permissions to the contacts have been denied to show this dialog.

## Context
<!--- Why is this change required? What problem does it solve? -->
References: https://outsystemsrd.atlassian.net/browse/RMET-1301


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [x] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [x] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
MABS 7.1 and MABS 8 builds working. Tested both in iOS 13 emulator and on my iPhone 11 running iOS 14.

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

![image](https://user-images.githubusercontent.com/27646996/149357585-e9a37002-a964-4eb8-96e3-952b4a538c00.png)


## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly