### PR TITLE
Fix ::: Android ::: PickContacts when there are multiple numbers

### DIFF
--- a/src/android/ContactAccessor.java
+++ b/src/android/ContactAccessor.java
@@ -16,22 +16,17 @@
 
 package org.apache.cordova.contacts;
 
-import java.util.HashMap;
-
-import android.Manifest;
-import android.content.pm.PackageManager;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.LOG;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.HashMap;
+
 /**
  * This abstract class defines SDK-independent API for communication with
- * Contacts Provider. The actual implementation used by the application depends
- * on the level of API available on the device. If the API level is Cupcake or
- * Donut, we want to use the {@link ContactAccessorSdk3_4} class. If it is
- * Eclair or higher, we want to use {@link ContactAccessorSdk5}.
+ * Contacts Provider.
  */
 public abstract class ContactAccessor {
 
@@ -52,7 +47,7 @@ public abstract class ContactAccessor {
 
     /**
      * Create a hash map of what data needs to be populated in the Contact object
-     * @param fields the list of fields to populate
+     * @param options the list of fields to populate
      * @return the hash map of required data
      */
     protected HashMap<String, Boolean> buildPopulationSet(JSONObject options) {
@@ -145,7 +140,7 @@ public abstract class ContactAccessor {
 
     /**
      * Handles adding a JSON Contact object into the database.
-     * @return TODO
+     * @return the raw id of the contact if successfully saved, null otherwise
      */
     public abstract String save(JSONObject contact);
 
@@ -155,17 +150,16 @@ public abstract class ContactAccessor {
     public abstract JSONArray search(JSONArray filter, JSONObject options);
 
     /**
-     * Handles searching through SDK-specific contacts API.
+     * Handles searching through SDK-specific contacts API using contact id.
      * @throws JSONException
      */
     public abstract JSONObject getContactById(String id) throws JSONException;
 
     /**
-     * Handles searching through SDK-specific contacts API.
-     * @param desiredFields fields that will filled. All fields will be filled if null
+     * Handles searching through SDK-specific contacts API using raw id.
      * @throws JSONException
      */
-    public abstract JSONObject getContactById(String id, JSONArray desiredFields) throws JSONException;
+    public abstract JSONObject getContactByRawId(String rawId) throws JSONException;
 
     /**
      * Handles removing a contact from the database.

--- a/src/android/ContactAccessor.java
+++ b/src/android/ContactAccessor.java
@@ -47,7 +47,7 @@ public abstract class ContactAccessor {
 
     /**
      * Create a hash map of what data needs to be populated in the Contact object
-     * @param options the list of fields to populate
+     * @param options the list of fields to populate, or null/empty if you want all data
      * @return the hash map of required data
      */
     protected HashMap<String, Boolean> buildPopulationSet(JSONObject options) {

--- a/src/android/ContactAccessorSdk5.java
+++ b/src/android/ContactAccessorSdk5.java
@@ -324,6 +324,8 @@ public class ContactAccessorSdk5 extends ContactAccessor {
     }
 
     private JSONObject getContactById(String idKey, String idValue) throws JSONException {
+        // passing null projection to retrieve all the columns from the DB
+        //  in other words, to get all contact data
         Cursor c = mApp.getActivity().getContentResolver().query(
                 ContactsContract.Data.CONTENT_URI,
                 null,
@@ -331,6 +333,7 @@ public class ContactAccessorSdk5 extends ContactAccessor {
                 new String[] { idValue },
                 idKey + " ASC"
         );
+        // passing null to populate all the contact's data
         HashMap<String, Boolean> populate = buildPopulationSet(
                 new JSONObject().put("desiredFields", null)
         );

--- a/src/android/ContactAccessorSdk5.java
+++ b/src/android/ContactAccessorSdk5.java
@@ -55,6 +55,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.sql.Date;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -308,7 +309,9 @@ public class ContactAccessorSdk5 extends ContactAccessor {
      */
     @Override
     public JSONObject getContactById(String id) throws JSONException {
-        return getContactById(ContactsContract.Data.CONTACT_ID, id);
+        return getContactById(
+                new AbstractMap.SimpleEntry<>(ContactsContract.Data.CONTACT_ID, id)
+        );
     }
 
     /**
@@ -320,18 +323,20 @@ public class ContactAccessorSdk5 extends ContactAccessor {
      */
     @Override
     public JSONObject getContactByRawId(String rawId) throws JSONException {
-        return getContactById(ContactsContract.Data.RAW_CONTACT_ID, rawId);
+        return getContactById(
+                new AbstractMap.SimpleEntry<>(ContactsContract.Data.RAW_CONTACT_ID, rawId)
+        );
     }
 
-    private JSONObject getContactById(String idColumnName, String id) throws JSONException {
+    private JSONObject getContactById(Map.Entry<String, String> idColumn) throws JSONException {
         // passing null projection to retrieve all the columns from the DB
         //  in other words, to get all contact data
         Cursor c = mApp.getActivity().getContentResolver().query(
                 ContactsContract.Data.CONTENT_URI,
                 null,
-                idColumnName + " = ? ",
-                new String[] { id },
-                idColumnName + " ASC"
+                idColumn.getKey() + " = ? ",
+                new String[] { idColumn.getValue() },
+                idColumn.getKey() + " ASC"
         );
         // passing null to populate all the contact's data
         HashMap<String, Boolean> populate = buildPopulationSet(

--- a/src/android/ContactAccessorSdk5.java
+++ b/src/android/ContactAccessorSdk5.java
@@ -323,15 +323,15 @@ public class ContactAccessorSdk5 extends ContactAccessor {
         return getContactById(ContactsContract.Data.RAW_CONTACT_ID, rawId);
     }
 
-    private JSONObject getContactById(String idKey, String idValue) throws JSONException {
+    private JSONObject getContactById(String idColumnName, String id) throws JSONException {
         // passing null projection to retrieve all the columns from the DB
         //  in other words, to get all contact data
         Cursor c = mApp.getActivity().getContentResolver().query(
                 ContactsContract.Data.CONTENT_URI,
                 null,
-                idKey + " = ? ",
-                new String[] { idValue },
-                idKey + " ASC"
+                idColumnName + " = ? ",
+                new String[] { id },
+                idColumnName + " ASC"
         );
         // passing null to populate all the contact's data
         HashMap<String, Boolean> populate = buildPopulationSet(

--- a/src/android/ContactAccessorSdk5.java
+++ b/src/android/ContactAccessorSdk5.java
@@ -308,14 +308,7 @@ public class ContactAccessorSdk5 extends ContactAccessor {
      */
     @Override
     public JSONObject getContactById(String id) throws JSONException {
-        Cursor c = mApp.getActivity().getContentResolver().query(
-                ContactsContract.Data.CONTENT_URI,
-                null,
-                ContactsContract.Data.CONTACT_ID + " = ? ",
-                new String[] { id },
-                ContactsContract.Data.CONTACT_ID + " ASC"
-        );
-        return getContactById(c);
+        return getContactById(ContactsContract.Data.CONTACT_ID, id);
     }
 
     /**
@@ -327,17 +320,17 @@ public class ContactAccessorSdk5 extends ContactAccessor {
      */
     @Override
     public JSONObject getContactByRawId(String rawId) throws JSONException {
+        return getContactById(ContactsContract.Data.RAW_CONTACT_ID, rawId);
+    }
+
+    private JSONObject getContactById(String idKey, String idValue) throws JSONException {
         Cursor c = mApp.getActivity().getContentResolver().query(
                 ContactsContract.Data.CONTENT_URI,
                 null,
-                ContactsContract.Data.RAW_CONTACT_ID + " = ? ",
-                new String[] { rawId },
-                ContactsContract.Data.RAW_CONTACT_ID + " ASC"
+                idKey + " = ? ",
+                new String[] { idValue },
+                idKey + " ASC"
         );
-        return getContactById(c);
-    }
-
-    private JSONObject getContactById(Cursor c) throws JSONException {
         HashMap<String, Boolean> populate = buildPopulationSet(
                 new JSONObject().put("desiredFields", null)
         );

--- a/src/android/ContactManager.java
+++ b/src/android/ContactManager.java
@@ -243,19 +243,8 @@ public class ContactManager extends CordovaPlugin {
         if (requestCode == CONTACT_PICKER_RESULT) {
             if (resultCode == Activity.RESULT_OK) {
                 String contactId = intent.getData().getLastPathSegment();
-                // to populate contact data we require  Raw Contact ID
-                // so we do look up for contact raw id first
-                Cursor c =  this.cordova.getActivity().getContentResolver().query(RawContacts.CONTENT_URI,
-                            new String[] {RawContacts._ID}, RawContacts.CONTACT_ID + " = " + contactId, null, null);
-                if (!c.moveToFirst()) {
-                    this.callbackContext.error("Error occured while retrieving contact raw id");
-                    return;
-                }
-                String id = c.getString(c.getColumnIndex(RawContacts._ID));
-                c.close();
-
                 try {
-                    JSONObject contact = contactAccessor.getContactById(id);
+                    JSONObject contact = contactAccessor.getContactById(contactId);
                     this.callbackContext.success(contact);
                     return;
                 } catch (JSONException e) {

--- a/src/android/ContactManager.java
+++ b/src/android/ContactManager.java
@@ -190,7 +190,7 @@ public class ContactManager extends CordovaPlugin {
                 String id = contactAccessor.save(contact);
                 if (id != null) {
                     try {
-                        res = contactAccessor.getContactById(id);
+                        res = contactAccessor.getContactByRawId(id);
                     } catch (JSONException e) {
                         LOG.e(LOG_TAG, "JSON fail.", e);
                     }


### PR DESCRIPTION
## Description

The Pick Contacts feature was searching the contacts using a raw contact id instead of the actual contact id - which means if a contact has multiple raw contacts - e.g. multiple phone numbers added at different points in time - not all contact information was being returned.

This PR fixes that issue.

## Context

References: https://outsystemsrd.atlassian.net/wiki/spaces/RDME/pages/4426137659/iOS+18+Android+15+Assessment

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests

Tested the following in multiple Android versions:

- Creating a contact with multiple phone numbers (either via the Contacts Sample App or the phone's actual Contacts app) - Then using find and pick features - they should return the exact same results
- Confirming that saving contacts with same name a different phone still working.



## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly