### PR TITLE
ci: Trigger release on push to outsystems

### DIFF
--- a/.github/workflows/release_plugin.yml
+++ b/.github/workflows/release_plugin.yml
@@ -1,6 +1,8 @@
 name: Release Cordova Plugin (GitHub)
 
 on:
+  push:
+    branches: [outsystems]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Initially #17 was meant to trigger manually, but after re-consideration, there's nothing stopping us from doing releases right after pushes to main; there's no advantage in bundling commits and features / fixes, because this plugin is not a customer-facing product, the OutSystems Plugin (which consumes this cordova plugin) is